### PR TITLE
Split current task

### DIFF
--- a/tasks/clean.yml
+++ b/tasks/clean.yml
@@ -1,0 +1,11 @@
+---
+
+- name: clean > Remove failed and old releases, keeping "{{ manala_deploy_releases }}" releases
+  deploy_helper:
+    path:          "{{ manala_deploy_dir }}"
+    current_path:  "{{ manala_deploy_current_dir }}"
+    releases_path: "{{ manala_deploy_releases_dir }}"
+    release:       "{{ deploy_helper.new_release }}"
+    keep_releases: "{{ manala_deploy_releases }}"
+    state:         clean
+  ignore_errors: true

--- a/tasks/current.yml
+++ b/tasks/current.yml
@@ -1,8 +1,0 @@
----
-
-- name: current > Finalize
-  deploy_helper:
-    path:          "{{ manala_deploy_dir }}"
-    keep_releases: "{{ manala_deploy_releases }}"
-    release:       "{{ deploy_helper.new_release }}"
-    state:         finalize

--- a/tasks/finalize.yml
+++ b/tasks/finalize.yml
@@ -1,0 +1,11 @@
+---
+
+- name: finalize > Remove the "{{ deploy_helper.unfinished_filename }}" file and create a symlink to the newly deployed release "{{ deploy_helper.release }}"
+  deploy_helper:
+    path:          "{{ manala_deploy_dir }}"
+    current_path:  "{{ manala_deploy_current_dir }}"
+    releases_path: "{{ manala_deploy_releases_dir }}"
+    release:       "{{ deploy_helper.new_release }}"
+    keep_releases: "{{ manala_deploy_releases }}"
+    state:         finalize
+    clean:         false

--- a/tasks/finalize.yml
+++ b/tasks/finalize.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: finalize > Remove the "{{ deploy_helper.unfinished_filename }}" file and create a symlink to the newly deployed release "{{ deploy_helper.release }}"
+- name: finalize > Remove the unfinished file and create a symlink to the newly deployed release
   deploy_helper:
     path:          "{{ manala_deploy_dir }}"
     current_path:  "{{ manala_deploy_current_dir }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,8 +43,13 @@
     - manala_deploy
     - manala_deploy.tasks
 
-# Current
-- include: current.yml
+# Finalize
+- include: finalize.yml
+  tags:
+    - manala_deploy
+
+# Clean
+- include: clean.yml
   tags:
     - manala_deploy
 


### PR DESCRIPTION
This allows the clean step to fail, without affecting the rest of the deploy process