### PR TITLE
Introduce unarchive strategy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,9 @@ manala_deploy_strategy_synchronize_src: ~
 manala_deploy_strategy_synchronize_dst: ~
 manala_deploy_strategy_synchronize_rsync_options: []
 
+# Strategy - Unarchive
+manala_deploy_strategy_unarchive_src: ~
+
 # Shared
 manala_deploy_shared_files: []
 manala_deploy_shared_dirs:  []

--- a/tasks/strategy/unarchive.yml
+++ b/tasks/strategy/unarchive.yml
@@ -1,0 +1,11 @@
+---
+
+- name: strategy/unarchive > Create dir
+  file:
+    path: "{{ deploy_helper.new_release_path }}/"
+    state: directory
+
+- name: strategy/unarchive > Unarchive
+  unarchive:
+    src: "{{ manala_deploy_strategy_unarchive_src }}"
+    dest: "{{ deploy_helper.new_release_path }}"


### PR DESCRIPTION
Allow to deploy a local archive.

```
manala_deploy_strategy: unarchive
manala_deploy_strategy_unarchive_src: "/tmp/build/release/prod/current.tar.gz"
```

> can handle .zip files using unzip as well as .tar, .tar.gz, .tar.bz2 and .tar.xz files using gtar

More information [here](https://docs.ansible.com/ansible/unarchive_module.html).